### PR TITLE
Refactor ManifestVersionResolver to use new ChannelSession API

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
         <version.org.jboss.galleon>6.0.3.Final</version.org.jboss.galleon>
         <version.org.mockito>5.13.0</version.org.mockito>
         <version.junit>4.13.2</version.junit>
-        <version.org.wildfly.channel>1.1.0.Final</version.org.wildfly.channel>
+        <version.org.wildfly.channel>1.2.0.Final</version.org.wildfly.channel>
         <version.assertj>3.26.3</version.assertj>
 
         <version.org.apache.maven.plugins.pmd>3.25.0</version.org.apache.maven.plugins.pmd>
@@ -95,4 +95,37 @@
             </plugin>
         </plugins>
     </reporting>
+
+    <repositories>
+        <repository>
+            <releases>
+                <enabled>true</enabled>
+                <updatePolicy>never</updatePolicy>
+            </releases>
+            <snapshots>
+                <enabled>true</enabled>
+                <updatePolicy>never</updatePolicy>
+            </snapshots>
+            <id>jboss-public-repository-group</id>
+            <name>JBoss Public Repository</name>
+            <url>https://repository.jboss.org/nexus/content/groups/public/</url>
+            <layout>default</layout>
+        </repository>
+    </repositories>
+    <pluginRepositories>
+        <pluginRepository>
+            <releases>
+                <enabled>true</enabled>
+                <updatePolicy>never</updatePolicy>
+            </releases>
+            <snapshots>
+                <enabled>true</enabled>
+                <updatePolicy>never</updatePolicy>
+            </snapshots>
+            <id>jboss-public-repository-group</id>
+            <name>JBoss Public Repository</name>
+            <url>https://repository.jboss.org/nexus/content/groups/public/</url>
+            <layout>default</layout>
+        </pluginRepository>
+    </pluginRepositories>
 </project>


### PR DESCRIPTION
Depracate old way of resolving versions of the manifests by using new ChannelSession API

Requires https://github.com/wildfly-extras/wildfly-channel/pull/300
