### PR TITLE
Implement pre-emptive authentication for URL-based metadata downloads

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -46,7 +46,7 @@
         <version.org.jboss.galleon>6.0.6.Final</version.org.jboss.galleon>
         <version.org.mockito>5.18.0</version.org.mockito>
         <version.junit>4.13.2</version.junit>
-        <version.org.wildfly.channel>1.2.2.Final</version.org.wildfly.channel>
+        <version.org.wildfly.channel>1.2.3.Final</version.org.wildfly.channel>
         <version.assertj>3.27.3</version.assertj>
 
         <version.org.apache.maven.plugins.pmd>3.26.0</version.org.apache.maven.plugins.pmd>

--- a/src/main/java/org/wildfly/prospero/metadata/ManifestVersionResolver.java
+++ b/src/main/java/org/wildfly/prospero/metadata/ManifestVersionResolver.java
@@ -30,6 +30,7 @@ import org.wildfly.channel.ChannelManifestMapper;
 import org.wildfly.channel.ChannelSession;
 import org.wildfly.channel.Repository;
 import org.wildfly.channel.RuntimeChannel;
+import org.wildfly.channel.UrlContentLoader;
 import org.wildfly.channel.maven.VersionResolverFactory;
 import org.wildfly.channel.spi.MavenVersionsResolver;
 import org.wildfly.channel.version.VersionMatcher;
@@ -188,7 +189,7 @@ public class ManifestVersionResolver {
     }
 
     private static String read(URL url) throws IOException {
-        try(InputStream inputStream = url.openStream();
+        try(InputStream inputStream = UrlContentLoader.openStream(url);
             OutputStream outputStream = new ByteArrayOutputStream()) {
             inputStream.transferTo(outputStream);
             return outputStream.toString();


### PR DESCRIPTION
The download happen in order to calculate metadata file hash.